### PR TITLE
fixed the order_date for pending orders on merchant show page

### DIFF
--- a/app/views/merchants/show.html.erb
+++ b/app/views/merchants/show.html.erb
@@ -39,7 +39,11 @@
         <% product.orders.reverse.each do |order| %>
           <section>
             <tr>
-              <td><%=order.purchase_time.strftime("%Y-%m-%d")%></td>
+              <% if order.status != 'pending' %>
+                <td><%=order.purchase_time.strftime("%Y-%m-%d")%></td>
+              <% else %>
+                <td>N/A</td>
+              <% end %>
               <td><%=order.id%></td>
               <td><%=order.name%></td>
               <td><%=order.status%></td>


### PR DESCRIPTION
If an order was pending, it didn't have an order date, and was breaking the merchant show page. I've made it so that if the order doesn't have a purchase_date, we instead display "N/A". 
